### PR TITLE
Fixed typographical error, changed appart to apart in README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 Broken since cloudapp 2.0!!
 
 cloudhost is either a clone from cloudapp or a proxy / data-storage build in php.
-The main difference is, you can host it on your own server completely appart from cloudapp or you can use it as a proxy until the file-upload starts.
+The main difference is, you can host it on your own server completely apart from cloudapp or you can use it as a proxy until the file-upload starts.
 You can use various cloudapp apps like the native os x cloudapp, fluffyapp (windows), cloudette or cloudrop (ios).
 
 Cloudhost supports nearly anything cloudapp does (except their fancy web-interface, at least not yet and the private/public state, since it's insecure anyway, like the non ssl traffic..). Even pusherapp to update changes on all your clients in realtime.


### PR DESCRIPTION
@john-dev, I've corrected a typographical error in the documentation of the [cloudhost](https://github.com/john-dev/cloudhost) project. You should be able to merge this pull request automatically. However, if this was intentional or if you enjoy living in linguistic squalor, please let me know and [create an issue](https://github.com/thoppe/orthographic-pedant/issues/new) on my home repository.